### PR TITLE
bugfix/configuration-cache-must-be-different-per-type Cache for calcu…

### DIFF
--- a/src/Scraper/Repositories/Configuration.php
+++ b/src/Scraper/Repositories/Configuration.php
@@ -16,8 +16,6 @@ class Configuration
      */
     private $configurator;
 
-    private $cacheKey = self::class . '-config';
-
     /**
      * Cache TTL in minutes.
      *
@@ -37,7 +35,8 @@ class Configuration
 
     public function calculate(string $type): Collection
     {
-        $config = Cache::get($this->cacheKey);
+        $cacheKey = $this->getCacheKey($type);
+        $config   = Cache::get($cacheKey);
         if (!$config) {
             Log::warning('Calculating configuration');
             $scrapedDataset = ScrapedDataset::withType($type)->get();
@@ -47,9 +46,14 @@ class Configuration
             }
 
             $config = $this->configurator->configureFromDataset($scrapedDataset);
-            Cache::put($this->cacheKey, $config, self::CACHE_TTL);
+            Cache::put($cacheKey, $config, self::CACHE_TTL);
         }
 
         return $config;
+    }
+
+    protected function getCacheKey(string $type): string
+    {
+        return self::class . "-config-{$type}";
     }
 }

--- a/tests/Unit/Scraper/Repositories/ConfigurationTest.php
+++ b/tests/Unit/Scraper/Repositories/ConfigurationTest.php
@@ -100,10 +100,10 @@ class ConfigurationTest extends TestCase
         ]);
 
         Cache::shouldReceive('get')
-            ->with($this->getCacheKey())
+            ->with(Configuration::class . '-config-post')
             ->andReturnNull();
         Cache::shouldReceive('put')
-            ->with($this->getCacheKey(), $config, Configuration::CACHE_TTL);
+            ->with(Configuration::class . '-config-post', $config, Configuration::CACHE_TTL);
 
         $configurator = \Mockery::mock(Configurator::class);
         $configurator->shouldReceive('configureFromDataset')
@@ -154,7 +154,7 @@ class ConfigurationTest extends TestCase
         ]);
 
         Cache::shouldReceive('get')
-            ->with($this->getCacheKey())
+            ->with(Configuration::class . '-config-post')
             ->andReturnNull();
 
         $configurator = \Mockery::mock(Configurator::class);
@@ -183,7 +183,7 @@ class ConfigurationTest extends TestCase
         $config = collect('configuration');
 
         Cache::shouldReceive('get')
-            ->with($this->getCacheKey())
+            ->with(Configuration::class . '-config-post')
             ->andReturn($config);
 
         $configuration = new Configuration($configurator);
@@ -191,10 +191,5 @@ class ConfigurationTest extends TestCase
             $config,
             $configuration->calculate('post')
         );
-    }
-
-    private function getCacheKey()
-    {
-        return Configuration::class . '-config';
     }
 }


### PR DESCRIPTION
…late configuration now take into account the configuration type