### PR TITLE
The scraped listener should be queued

### DIFF
--- a/src/Scraper/Listeners/ScrapeFailedListener.php
+++ b/src/Scraper/Listeners/ScrapeFailedListener.php
@@ -3,8 +3,9 @@
 namespace Softonic\LaravelIntelligentScraper\Scraper\Listeners;
 
 use Softonic\LaravelIntelligentScraper\Scraper\Events\ScrapeFailed;
+use Illuminate\Contracts\Queue\ShouldQueue;
 
-class ScrapeFailedListener
+class ScrapeFailedListener implements ShouldQueue
 {
     private $listeners;
 

--- a/src/Scraper/Listeners/ScrapedListener.php
+++ b/src/Scraper/Listeners/ScrapedListener.php
@@ -3,8 +3,9 @@
 namespace Softonic\LaravelIntelligentScraper\Scraper\Listeners;
 
 use Softonic\LaravelIntelligentScraper\Scraper\Events\Scraped;
+use Illuminate\Contracts\Queue\ShouldQueue;
 
-class ScrapedListener
+class ScrapedListener implements ShouldQueue
 {
     private $listeners;
 


### PR DESCRIPTION
The listeners configured for failed and successful scrapes should be queued to avoid interaction with the scrape part.